### PR TITLE
i#2083: Reference comparison tables above 2GB (#2224)

### DIFF
--- a/drmemory/fastpath_x86.c
+++ b/drmemory/fastpath_x86.c
@@ -1388,6 +1388,50 @@ insert_cmp_for_equality(void *drcontext, instrlist_t *bb, instr_t *inst,
     }
 }
 
+/* Assumes base_reg is pointer-sized but only contains data in the bottom 16 bits. */
+static int
+insert_table_access_pre(void *drcontext, instrlist_t *bb, instr_t *inst,
+                        ptr_int_t table_addr, reg_id_t base_reg)
+{
+    int disp = (int) table_addr;
+#ifdef X64
+    if (disp == table_addr)
+        return disp;
+    /* To avoid having to spill yet another register to access a table not in the low
+     * 2GB, we add the high 32 bits of the address to the base register.
+     * An alternative would be to mmap space in the low 2GB and copy our tables there:
+     * but __PAGEZERO makes that impossible on Mac, and we do not have enough TLS
+     * slots to copy our tables there.  Xref i#2083.
+     */
+    LOG(4, "%s: table addr " PFX " >2GB so using ror,or,ror to add upper bits.\n",
+        __FUNCTION__, table_addr);
+    PRE(bb, inst,
+        INSTR_CREATE_ror(drcontext, opnd_create_reg(base_reg), OPND_CREATE_INT8(32)));
+    int top_bits = (int)((table_addr - disp) >> 32);
+    PRE(bb, inst,
+        INSTR_CREATE_or(drcontext, opnd_create_reg(base_reg),
+                        OPND_CREATE_INT32(top_bits)));
+    PRE(bb, inst,
+        INSTR_CREATE_ror(drcontext, opnd_create_reg(base_reg), OPND_CREATE_INT8(32)));
+#endif
+    return disp;
+}
+
+static void
+insert_table_access_post(void *drcontext, instrlist_t *bb, instr_t *inst,
+                         ptr_int_t table_addr, reg_id_t base_reg)
+{
+#ifdef X64
+    int disp = (int) table_addr;
+    if (disp == table_addr)
+        return;
+    /* Clear the top bits again. */
+    reg_id_t reg32 = reg_ptrsz_to_32(base_reg);
+    PRE(bb, inst,
+        INSTR_CREATE_mov_ld(drcontext, opnd_create_reg(reg32), opnd_create_reg(reg32)));
+#endif
+}
+
 /* Adds a check that app_op's shadow in shadow_op has its shadow bits
  * defined.  mi->src_opsz is assumed to be the size.
  */
@@ -1465,15 +1509,16 @@ insert_check_defined(void *drcontext, instrlist_t *bb, instr_t *inst,
                      mi->xl8));
         }
         mark_eflags_used(drcontext, bb, mi->bb);
-        ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_byte_defined);
-        ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_word_defined);
-        disp += (int)(ptr_int_t)
+
+        ptr_int_t table_addr = (ptr_int_t)
             ((sz == 1) ? shadow_byte_defined : shadow_word_defined);
+        disp += insert_table_access_pre(drcontext, bb, inst, table_addr, base);
         /* look up in series of 4 tables, one for each offset */
         PRE(bb, inst,
             INSTR_CREATE_cmp(drcontext,
                              opnd_create_base_disp(base, index, 1, disp, OPSZ_1),
                              OPND_CREATE_INT8(1)));
+        insert_table_access_post(drcontext, bb, inst, table_addr, base);
     } else {
         if (oi != NULL && oi->indir_size != OPSZ_NA) {
             reg_id_t indir_tgt = reg_to_size(mi->reg3.reg, shadow_reg_indir_size(oi));
@@ -2598,15 +2643,14 @@ add_dst_shadow_write(void *drcontext, instrlist_t *bb, instr_t *inst,
 
             if (instr_get_opcode(inst) == OP_movsx) {
                 reg_id_t reg32 = reg_to_pointer_sized(opnd_get_reg(opreg1));
-                int disp;
                 PRE(bb, inst, INSTR_CREATE_movzx
                     (drcontext, opnd_create_reg(reg32), opreg1));
-                ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_2_to_dword);
-                ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_4_to_dword);
-                disp = (int)(ptr_int_t)((src_opsz == 1) ?
-                                        shadow_2_to_dword : shadow_4_to_dword);
+                ptr_int_t table_addr = (ptr_int_t)
+                    ((src_opsz == 1) ? shadow_2_to_dword : shadow_4_to_dword);
+                int disp = insert_table_access_pre(drcontext, bb, inst, table_addr, reg32);
                 PRE(bb, inst, INSTR_CREATE_mov_ld
                     (drcontext, opreg1, OPND_CREATE_MEM8(reg32, disp)));
+                insert_table_access_post(drcontext, bb, inst, table_addr, reg32);
             }
 
             /* Write result */
@@ -3383,12 +3427,13 @@ instrument_fastpath(void *drcontext, instrlist_t *bb, instr_t *inst,
              */
             ASSERT(mi->memsz == 4, "only word-sized mem2mem prop supported");
             /* Check for unaddressability via table lookup */
-            ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_dword_is_addr_not_bit);
-            disp = (int)(ptr_int_t)shadow_dword_is_addr_not_bit;
+            ptr_int_t table_addr = (ptr_int_t)shadow_dword_is_addr_not_bit;
+            disp = insert_table_access_pre(drcontext, bb, inst, table_addr, mi->reg3.reg);
             PRE(bb, inst,
                 INSTR_CREATE_cmp(drcontext,
                                  OPND_CREATE_MEM8(mi->reg3.reg, disp),
                                  OPND_CREATE_INT8(1)));
+            insert_table_access_post(drcontext, bb, inst, table_addr, mi->reg3.reg);
             mi->src[0].shadow = opnd_create_reg(mi->reg3_8);
             /* shouldn't be other srcs */
             ASSERT(opnd_is_null(mi->src[1].shadow), "mem2mem error");
@@ -3801,24 +3846,27 @@ instrument_fastpath(void *drcontext, instrlist_t *bb, instr_t *inst,
                  * rest of mi->memoffs and in 8h position it's doing x256 already.
                  */
                 reg_id_t idx = reg_to_pointer_sized(opnd_get_reg(mi->memoffs));
-                ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_byte_addr_not_bit);
-                ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_word_addr_not_bit);
-                disp = (int)(ptr_int_t) ((mi->memsz == 1) ?
-                                         shadow_byte_addr_not_bit :
-                                         shadow_word_addr_not_bit);
+                ptr_int_t table_addr = (ptr_int_t) ((mi->memsz == 1) ?
+                                                    shadow_byte_addr_not_bit :
+                                                    shadow_word_addr_not_bit);
+                int disp = insert_table_access_pre(drcontext, bb, inst, table_addr,
+                                                   mi->reg2.reg);
                 ASSERT(mi->zero_rest_of_offs, "table lookup requires zeroing");
                 PRE(bb, inst,
                     INSTR_CREATE_cmp(drcontext,
                                      opnd_create_base_disp(mi->reg2.reg, idx,
                                                            1, disp, OPSZ_1),
                                      OPND_CREATE_INT8(1)));
+                insert_table_access_post(drcontext, bb, inst, table_addr, mi->reg2.reg);
             } else {
-                ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_dword_is_addr_not_bit);
-                disp = (int)(ptr_int_t)shadow_dword_is_addr_not_bit;
+                ptr_int_t table_addr = (ptr_int_t)shadow_dword_is_addr_not_bit;
+                disp = insert_table_access_pre(drcontext, bb, inst, table_addr,
+                                               mi->reg2.reg);
                 PRE(bb, inst,
                     INSTR_CREATE_cmp(drcontext,
                                      OPND_CREATE_MEM8(mi->reg2.reg, disp),
                                      OPND_CREATE_INT8(1)));
+                insert_table_access_post(drcontext, bb, inst, table_addr, mi->reg2.reg);
             }
         } else {
             /* Conservative check for addressability: check for definedness.
@@ -3930,28 +3978,28 @@ instrument_fastpath(void *drcontext, instrlist_t *bb, instr_t *inst,
                     /* PR 503782: check just the bytes referenced.  We've zeroed the
                      * rest of mi->memoffs and in 8h position it's doing x256 already.
                      */
-                    int disp;
                     reg_id_t idx = reg_to_pointer_sized(opnd_get_reg(mi->memoffs));
-                    ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_byte_addr_not_bit);
-                    ASSERT_TRUNCATE(disp, int, (ptr_int_t)shadow_word_addr_not_bit);
-                    disp = (int)(ptr_int_t) ((mi->memsz == 1) ?
-                                             shadow_byte_addr_not_bit :
-                                             shadow_word_addr_not_bit);
+                    ptr_int_t table_addr = (ptr_int_t)
+                        ((mi->memsz == 1) ? shadow_byte_addr_not_bit :
+                         shadow_word_addr_not_bit);
+                    int disp = insert_table_access_pre(drcontext, bb, inst, table_addr,
+                                                       scratch);
                     ASSERT(mi->zero_rest_of_offs, "table lookup requires zeroing");
                     PRE(bb, inst,
                         INSTR_CREATE_cmp(drcontext,
                                          opnd_create_base_disp(scratch, idx,
                                                                1, disp, OPSZ_1),
                                          OPND_CREATE_INT8(1)));
+                    insert_table_access_post(drcontext, bb, inst, table_addr, scratch);
                 } else {
-                    int disp;
-                    ASSERT_TRUNCATE(disp, int,
-                                    (ptr_int_t)shadow_dword_is_addr_not_bit);
-                    disp = (int)(ptr_int_t)shadow_dword_is_addr_not_bit;
+                    ptr_int_t table_addr = (ptr_int_t)shadow_dword_is_addr_not_bit;
+                    int disp = insert_table_access_pre(drcontext, bb, inst, table_addr,
+                                                       scratch);
                     PRE(bb, inst,
                         INSTR_CREATE_cmp(drcontext, OPND_CREATE_MEM8
                                          (scratch, disp),
                                          OPND_CREATE_INT8(1)));
+                    insert_table_access_post(drcontext, bb, inst, table_addr, scratch);
                 }
                 /* we only check for 1 unaddr shadow so only check if haven't already */
                 if (check_ignore_unaddr && opnd_is_null(heap_unaddr_shadow)) {

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -104,12 +104,10 @@
  *   default 128MB reservation.  DR is more efficient when all its
  *   allocations are inside its reservation.
  * DRi#1081: we disable reset until the DR bug is fixed.
- * i#2083: disable hard-to-reach tables via -no_vm_base_near_app until a long-term
- *   fix is in place that loads tables via an extra scratch reg.
  */
 #define DEFAULT_DR_OPS \
     "-disable_traces -bb_single_restore_prefix -max_bb_instrs 256 -vm_size 256M "\
-    "-no_enable_reset -no_vm_base_near_app"
+    "-no_enable_reset"
 
 #define DRMEM_CLIENT_ID 0
 


### PR DESCRIPTION
Adds support for loading from shadow value comparison tables that cannot be
reached by a single 32-bit displacement.  To avoid needing another scratch
register, we instead use the top bits of the register holding the shadow
value, inserting the top 32 bits of the table address using a sequence
ror;or;ror, and then clearing after the comparison.

Fixes #2083