### PR TITLE
i#2184: add Umbra support for Control Flow Guard 2TB reservation (#2236)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,12 @@ if (UNIX)
   # disabling strict aliasing since giving weird warning I'm not sure how to fix:
   #   alloc.c:716: warning: dereferencing type-punned pointer will break strict-aliasing rules
   set(WARN "-Wall -Werror -Wno-strict-aliasing")
+  # Disabling format-truncation due to too many warnings about string construction
+  # where truncating added strings is fine if the final doesn't fit anyway.
+  CHECK_C_COMPILER_FLAG("-Wno-format-truncation" have_format_truncation_warning)
+  if (have_format_truncation_warning)
+    set(WARN "${WARN} -Wno-format-truncation")
+  endif ()
   if (CMAKE_C_COMPILER MATCHES "/build/toolchain")
     # needed for linux/ipmi.h (PR 531644)
     set(EXTRA_FLAGS "-idirafter /build/toolchain/lin32/glibc-2007q3-51/usr/include")

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -142,6 +142,12 @@ use_DynamoRIO_extension(drfuzz_test_no_crash.client drsyms)
 
 set(asm_defs "${asm_defs}" -I "${CMAKE_CURRENT_SOURCE_DIR}") # for umbra_test_shared.h
 add_drmf_test_app(umbra_app umbra_app.c)
+if (WIN32)
+  # Try to test i#2184 where Control Flow Guard allocates a 2TB reservation
+  # crossing multiple Umbra segments.  I can only repro that with VS2017, but
+  # we put this in place in anticipation of updating to VS2017.
+  append_property_string(TARGET umbra_app COMPILE_FLAGS "/guard:cf")
+endif ()
 target_include_directories(umbra_app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_drmf_test(umbra_test_empty      umbra_app umbra_client_empty.c
@@ -167,3 +173,6 @@ use_DynamoRIO_extension(umbra_test_consistency.client drreg)
 use_DynamoRIO_extension(umbra_test_consistency.client drutil)
 target_include_directories(umbra_test_consistency.client PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_drmf_test(umbra_test_allscales umbra_app umbra_client_allscales.c
+  umbra "" ".*TEST PASSED")

--- a/tests/framework/umbra_client_allscales.c
+++ b/tests/framework/umbra_client_allscales.c
@@ -1,0 +1,76 @@
+/* **************************************************************
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * **************************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests that there are no conflicts in any scale factor with the target
+ * application.
+ */
+
+#include <string.h>
+
+#include "dr_api.h"
+#include "umbra.h"
+
+/* We don't want a popup so we don't use DR_ASSERT_MSG. */
+#define CHECK(cond, msg) ((void)((cond) ? 0 :                   \
+    (dr_fprintf(STDERR,  "ASSERT FAILURE: %s:%d: %s (%s)\n",    \
+                __FILE__, __LINE__, #cond, msg), dr_abort(), 0)))
+
+static void
+test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label)
+{
+    dr_printf("\n====================\ntesting scale %d == %s\n", scale, label);
+    umbra_map_t *umbra_map;
+    umbra_map_options_t umbra_map_ops;
+    memset(&umbra_map_ops, 0, sizeof(umbra_map_ops));
+    umbra_map_ops.scale = scale;
+    umbra_map_ops.flags = UMBRA_MAP_CREATE_SHADOW_ON_TOUCH |
+        UMBRA_MAP_SHADOW_SHARED_READONLY;
+    umbra_map_ops.default_value = 0;
+    umbra_map_ops.default_value_size = 1;
+    if (umbra_init(id) != DRMF_SUCCESS)
+        CHECK(false, "failed to init umbra");
+    if (umbra_create_mapping(&umbra_map_ops, &umbra_map) != DRMF_SUCCESS)
+        CHECK(false, "failed to create shadow memory mapping");
+    if (umbra_destroy_mapping(umbra_map) != DRMF_SUCCESS)
+        CHECK(false, "failed to destroy shadow memory mapping");
+    umbra_exit();
+}
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_8X, "down 8x");
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_4X, "down 4x");
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_2X, "down 2x");
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_SAME_1X, "one-to-one");
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_UP_2X, "up 2x");
+}

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -60,17 +60,18 @@
  * 0x10' (i#1810): they carve out two regions inside 0x10'-0x300' which
  * we merge with the bottom region:
  *   app1: [0x00000000'00000000, 0x00000300'00000000): exec, heap, data
- *   app2: [0x00007FF0'00000000, 0x00008000'00000000): libs
+ *   app2: [0x00007C00'00000000, 0x00008000'00000000): libs
  * 1B-to-1B mapping:
- *   SHDW(app) = (app & 0x00000FFF'FFFFFFFF) + 0x00000400'00000000)
+ *   SHDW(app) = (app & 0x00000FFF'FFFFFFFF) + 0x00000700'00000000)
  * and the result:
- *   shdw1 = SHDW(app1): [0x00000400'00000000, 0x00000700'00000000)
- *   shdw2 = SHDW(app2): [0x000013f0'00000000, 0x00001400'00000000)
+ *   shdw1 = SHDW(app1): [0x00000700'00000000, 0x00000a00'00000000)
+ *   shdw2 = SHDW(app2): [0x00001300'00000000, 0x00001700'00000000)
  * and
- *   shdw1'= SHDW(shdw1): [0x00000800'00000000, 0x00000b00'00000000)
- *   shdw2'= SHDW(shdw2): [0x000007f0'00000000, 0x00000800'00000000)
+ *   shdw1'= SHDW(shdw1): [0x00000e00'00000000, 0x00001100'00000000)
+ *   shdw2'= SHDW(shdw2): [0x00000a00'00000000, 0x00000e00'00000000)
  * Here we call [0x00000000'00000000, 0x00001000'00000000) a unit, and each
- * unit has 16 segments with size of 0x100'00000000.
+ * unit has 16 segments with size of 0x100'00000000.  Note that we do allow
+ * multi-segment regions.
  *
  * Linux:
  * app1: [0x00000000'00000000, 0x00000100'00000000): exec, heap, data
@@ -112,31 +113,31 @@
  * An extra layer of protection.
  *
  * For scaling up or down:
- * Windows:
+ * Windows 8.1+:
  * For scale down 2X:
- *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00000040'00000000) >> 1
- *   SHDW(app1): [0x00000020'00000000, 0x00000028'00000000)
- *   SHDW(app2): [0x00000098'00000000, 0x000000A0'00000000)
- *   SHDW(shdw1): [0x00000030'00000000, 0x00000034'00000000)
- *   SHDW(shdw2): [0x0000006C'00000000, 0x00000070'00000000)
+ *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00000800'00000000) >> 1
+ *   SHDW(app1): [0x00000400'00000000, 0x00000580'00000000)
+ *   SHDW(app2): [0x00000a00'00000000, 0x00000c00'00000000)
+ *   SHDW(shdw1): [0x00000600'00000000, 0x000006c0'00000000)
+ *   SHDW(shdw2): [0x00000900'00000000, 0x00000a00'00000000)
  * For scale down 4X:
- *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00000080'00000000) >> 2
- *   SHDW(app1): [0x00000020'00000000, 0x00000024'00000000)
- *   SHDW(app2): [0x0000005C'00000000, 0x00000060'00000000)
- *   SHDW(shdw1): [0x00000028'00000000, 0x00000029'00000000)
- *   SHDW(shdw2): [0x00000037'00000000, 0x00000038'00000000)
+ *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00001c00'00000000) >> 2
+ *   SHDW(app1): [0x00000700'00000000, 0x000007c0'00000000)
+ *   SHDW(app2): [0x00000a00'00000000, 0x00000b00'00000000)
+ *   SHDW(shdw1): [0x000008c0'00000000, 0x000008f0'00000000)
+ *   SHDW(shdw2): [0x00000980'00000000, 0x000009c0'00000000)
  * For scale down 8X:
- *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00000100'00000000) >> 3
- *   SHDW(app1): [0x00000020'00000000, 0x00000022'00000000)
- *   SHDW(app2): [0x0000003E'00000000, 0x00000040'00000000)
- *   SHDW(shdw1): [0x00000024'00000000, 0x00000024'40000000)
- *   SHDW(shdw2): [0x00000027'C0000000, 0x00000028'00000000)
+ *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00003800'00000000) >> 3
+ *   SHDW(app1): [0x00000700'00000000, 0x00000760'00000000)
+ *   SHDW(app2): [0x00000880'00000000, 0x00000900'00000000)
+ *   SHDW(shdw1): [0x000007e0'00000000, 0x000007ec'00000000)
+ *   SHDW(shdw2): [0x00000810'00000000, 0x00000820'00000000)
  * For scale up 2X:
- *  SHDW(app) = ((app & 0x000000FF'FFFFFFFF) + 0x00000018'00000000) << 1
- *   SHDW(app1): [0x00000030'00000000, 0x00000050'00000000)
- *   SHDW(app2): [0x00000210'00000000, 0x00000230'00000000)
- *   SHDW(shdw1): [0x00000090'00000000, 0x000000D0'00000000)
- *   SHDW(shdw2): [0x00000050'00000000, 0x00000090'00000000)
+ *  SHDW(app) = ((app & 0x000001FF'FFFFFFFF) + 0x00000580'00000000) << 1
+ *   SHDW(app1): [0x00000b00'00000000, 0x00001100'00000000)
+ *   SHDW(app2): [0x00004300'00000000, 0x00004b00'00000000)
+ *   SHDW(shdw1): [0x00001100'00000000, 0x00002100'00000000)
+ *   SHDW(shdw2): [0x00002100'00000000, 0x00002d00'00000000)
  *
  * Similar for Linux: xref i#1782 about the disp value
  * For scale down 2X:
@@ -334,21 +335,25 @@ static ptr_uint_t map_disp[] = {
 };
 
 #ifdef WINDOWS
-# define WIN81_BASE_DISP 0x40000000000
+# define WIN81_BASE_DISP 0x70000000000
+/* 0x700' does not work for DOWN_2X where reserve overlaps shadow. */
+# define WIN81_BASE_DISP_DOWN2 0x40000000000
+/* 0x700' also does not work for UP_2X. */
+# define WIN81_BASE_DISP_UP2 0xb0000000000
 static ptr_uint_t map_disp_win81[] = {
     (WIN81_BASE_DISP)<<3, /* UMBRA_MAP_SCALE_DOWN_8X */
     (WIN81_BASE_DISP)<<2, /* UMBRA_MAP_SCALE_DOWN_4X */
-    (WIN81_BASE_DISP)<<1, /* UMBRA_MAP_SCALE_DOWN_2X */
+    (WIN81_BASE_DISP_DOWN2)<<1, /* UMBRA_MAP_SCALE_DOWN_2X */
     (WIN81_BASE_DISP),    /* UMBRA_MAP_SCALE_SAME_1X */
-    (WIN81_BASE_DISP)>>1, /* UMBRA_MAP_SCALE_UP_2X */
+    (WIN81_BASE_DISP_UP2)>>1, /* UMBRA_MAP_SCALE_UP_2X */
 };
 #endif
 
 /* List all the mappings we support, no other app segment is allowed.
  * We check conflicts later when creating shadow memory.
  */
-static app_segment_t app_segments[] = {
 #ifdef LINUX
+static const app_segment_t app_segments_initial[] = {
     /* We split app3 [0x7F0000000000, 0x800000000000) into two parts:
      * [0x7F0000000000, 0x7FFFFF400000) and [0x7FFFFF800000, 0x800000000000).
      * And we skip [0x7FFFFF400000-0x7FFFFF800000)
@@ -372,14 +377,39 @@ static app_segment_t app_segments[] = {
     {(app_pc)0xFFFFFFFFFF400000,  (app_pc)0xFFFFFFFFFF800000, 0},
     /* app3: part 2 */
     {(app_pc)0x00007FFFFF800000,  (app_pc)0x0000800000000000, 0},
-#endif
     /* for all additional segments */
     { NULL, NULL, 0 },
     { NULL, NULL, 0 },
     { NULL, NULL, 0 },
     { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
 };
-#define MAX_NUM_APP_SEGMENTS sizeof(app_segments)/sizeof(app_segments[0])
+#else
+static const app_segment_t app_segments_initial[] = {
+    /* for all additional segments */
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+};
+static const app_segment_t app_segments_initial_81[] = {
+    {(app_pc)0x0000000000000000,  (app_pc)0x0000030000000000, 0},
+    /* To ensure we cover large mappings such as from Control Flow Guard without
+     * first creating too-small entries, we have one large upper region covering
+     * multiple segments.  We only support this for Win8.1+.
+     */
+    {(app_pc)0x00007C0000000000,  (app_pc)0x0000800000000000, 0},
+    /* for all additional segments */
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+};
+#endif
+#define MAX_NUM_APP_SEGMENTS sizeof(app_segments_initial)/sizeof(app_segments_initial[0])
+static app_segment_t app_segments[MAX_NUM_APP_SEGMENTS];
 
 /***************************************************************************
  * UTILITY ROUTINES
@@ -453,8 +483,7 @@ umbra_add_shadow_segment(umbra_map_t *map, app_segment_t *seg)
     for (i = 0; i < MAX_NUM_APP_SEGMENTS; i++) {
         app_pc base, end;
         uint   map_idx;
-        /* skip my own app-segment*/
-        if (!app_segments[i].app_used || seg == &app_segments[i])
+        if (!app_segments[i].app_used)
             continue;
         /* new app-seg vs other app-seg's shadow and reserve */
         base = seg->app_base;
@@ -469,9 +498,14 @@ umbra_add_shadow_segment(umbra_map_t *map, app_segment_t *seg)
                                 app_segments[i].reserve_base[map_idx],
                                 app_segments[i].reserve_end[map_idx])) {
                 ELOG(1, "ERROR: new app segment ["PFX", "PFX")"
-                     " conflicts with app seg ["PFX", "PFX")\n",
+                     " conflicts with app seg ["PFX", "PFX") or its "
+                     "shadow ["PFX", "PFX") or reserve ["PFX", "PFX")\n",
                      seg->app_base, seg->app_end,
-                     app_segments[i].app_base, app_segments[i].app_end);
+                     app_segments[i].app_base, app_segments[i].app_end,
+                     app_segments[i].shadow_base[map_idx],
+                     app_segments[i].shadow_end[map_idx],
+                     app_segments[i].reserve_base[map_idx],
+                     app_segments[i].reserve_end[map_idx]);
                 return false;
             }
         }
@@ -484,16 +518,22 @@ umbra_add_shadow_segment(umbra_map_t *map, app_segment_t *seg)
             if (segment_overlap(base, end,
                                 app_segments[i].app_base,
                                 app_segments[i].app_end) ||
-                segment_overlap(base, end,
-                                app_segments[i].shadow_base[map_idx],
-                                app_segments[i].shadow_end[map_idx]) ||
+                (seg != &app_segments[i] &&
+                 segment_overlap(base, end,
+                                 app_segments[i].shadow_base[map_idx],
+                                 app_segments[i].shadow_end[map_idx])) ||
                 segment_overlap(base, end,
                                 app_segments[i].reserve_base[map_idx],
                                 app_segments[i].reserve_end[map_idx])) {
                 ELOG(1, "ERROR: new app segment ["PFX", "PFX")'s shadow segment "
-                     "["PFX", "PFX") conflicts with app seg ["PFX", "PFX")\n",
+                     "["PFX", "PFX") conflicts with app seg ["PFX", "PFX") or its "
+                     "shadow ["PFX", "PFX") or reserve ["PFX", "PFX")\n",
                      seg->app_base, seg->app_end, base, end,
-                     app_segments[i].app_base, app_segments[i].app_end);
+                     app_segments[i].app_base, app_segments[i].app_end,
+                     app_segments[i].shadow_base[map_idx],
+                     app_segments[i].shadow_end[map_idx],
+                     app_segments[i].reserve_base[map_idx],
+                     app_segments[i].reserve_end[map_idx]);
                 return false;
             }
         }
@@ -512,9 +552,12 @@ umbra_add_shadow_segment(umbra_map_t *map, app_segment_t *seg)
                                 app_segments[i].shadow_base[map_idx],
                                 app_segments[i].shadow_end[map_idx])) {
                 ELOG(1, "ERROR: new app segment ["PFX", "PFX")'s reserve segment "
-                     "["PFX", "PFX") conflicts with app seg ["PFX", "PFX")\n",
+                     "["PFX", "PFX") conflicts with app seg ["PFX", "PFX") or its "
+                     "shadow ["PFX", "PFX")\n",
                      seg->app_base, seg->app_end, base, end,
-                     app_segments[i].app_base, app_segments[i].app_end);
+                     app_segments[i].app_base, app_segments[i].app_end,
+                     app_segments[i].shadow_base[map_idx],
+                     app_segments[i].shadow_end[map_idx]);
                 return false;
             }
         }
@@ -546,24 +589,20 @@ umbra_add_app_segment(app_pc base, size_t size, umbra_map_t *map)
                     return true;
                 }
             } else {
-                /* we do not support a memory range span multiple segments */
-                if ((segment_base(num_seg_bits, base) !=
-                     segment_base(num_seg_bits, base + size)) &&
-                    (segment_base(num_seg_bits, base) +
-                     segment_size(num_seg_bits) != (ptr_uint_t)base + size)) {
-                    LOG(1, "memory ["PFX", "PFX") spanning multiple segments "
-                        "is not supported\n", base, base + size);
-                    return false;
-                }
                 app_segments[i].app_base = (app_pc)segment_base(num_seg_bits, base);
-                app_segments[i].app_end = (app_pc)app_segments[i].app_base +
-                    segment_size(num_seg_bits);
+                /* We do support a memory range spanning multiple segments, since it
+                 * happens in practice with Control Flow Guard (i#2184).
+                 */
+                app_segments[i].app_end =
+                    (app_pc)ALIGN_FORWARD(base + size, segment_size(num_seg_bits));
+                LOG(1, "adding app segment ["PFX", "PFX")\n", app_segments[i].app_base,
+                    app_segments[i].app_end);
                 /* Adding a not pre-defined segment.
                  * We call umbra_add_shadow_segment to check if it is valid.
                  */
                 if (map != NULL && !umbra_add_shadow_segment(map, &app_segments[i])) {
                     app_segments[i].app_end = NULL;
-                    LOG(1, "fail to add shadow segment for ["PFX", "PFX")\n",
+                    LOG(1, "failed to add shadow segment for ["PFX", "PFX")\n",
                         base, base + size);
                     return false;
                 }
@@ -572,6 +611,8 @@ umbra_add_app_segment(app_pc base, size_t size, umbra_map_t *map)
             }
         }
     }
+    LOG(1, "no room for new app segment ["PFX", "PFX")\n",
+        base, base + size);
     return false;
 }
 
@@ -585,6 +626,8 @@ umbra_address_space_init()
     while (pc < (app_pc)POINTER_MAX && dr_query_memory_ex(pc, &info)) {
         if (info.type != DR_MEMTYPE_FREE &&
             !umbra_add_app_segment(info.base_pc, info.size, NULL)) {
+            LOG(1, "ERROR: %s failed for " PFX "-" PFX "\n", __FUNCTION__,
+                info.base_pc, info.base_pc + info.size);
             return false;
         }
         if (POINTER_OVERFLOW_ON_ADD(pc, info.size)) {
@@ -672,11 +715,14 @@ umbra_arch_init()
         return DRMF_ERROR;
     if (os_version.version >= DR_WINDOWS_VERSION_8_1) {
         num_seg_bits = NUM_SEG_BITS_WIN8_1;
+        memcpy(&app_segments, &app_segments_initial_81, sizeof(app_segments));
     } else {
         num_seg_bits = NUM_SEG_BITS_WIN8;
+        memcpy(&app_segments, &app_segments_initial, sizeof(app_segments));
     }
 #else
     num_seg_bits = NUM_SEG_BITS;
+    memcpy(&app_segments, &app_segments_initial, sizeof(app_segments));
 #endif
     if (!umbra_address_space_init())
         return DRMF_ERROR;
@@ -686,6 +732,7 @@ umbra_arch_init()
 void
 umbra_arch_exit()
 {
+    memset(&app_segments, 0, sizeof(app_segments));
 }
 
 drmf_status_t
@@ -705,6 +752,14 @@ umbra_map_arch_init(umbra_map_t *map, umbra_map_options_t *ops)
            map->app_block_size    >= ALLOC_UNIT_SIZE,
            "block size too small");
     map->mask = segment_mask(num_seg_bits) | seg_index_mask(num_seg_bits);
+#ifdef WINDOWS
+    if (UMBRA_MAP_SCALE_IS_UP(map->options.scale)) {
+        /* The only way we can avoid reserves from wrapping around or overlapping
+         * is to pull one higher-level bit.
+         */
+        map->mask |= 0x0000100000000000;
+    }
+#endif
     map->disp = IF_WINDOWS((os_version.version >= DR_WINDOWS_VERSION_8_1) ?
                            map_disp_win81[map->options.scale] :)
         map_disp[map->options.scale];
@@ -718,8 +773,11 @@ umbra_map_arch_init(umbra_map_t *map, umbra_map_options_t *ops)
     /* now we add shadow memory segment */
     for (i = 0; i < MAX_NUM_APP_SEGMENTS; i++) {
         if (app_segments[i].app_used &&
-            !umbra_add_shadow_segment(map, &app_segments[i]))
+            !umbra_add_shadow_segment(map, &app_segments[i])) {
+            LOG(1, "ERROR: shadow segment failed for " PFX "-" PFX "\n",
+                app_segments[i].app_base, app_segments[i].app_end);
             return DRMF_ERROR_DETAILS_UNKNOWN;
+        }
     }
     return DRMF_SUCCESS;
 }
@@ -739,14 +797,19 @@ umbra_map_arch_exit(umbra_map_t *map)
     uint i;
     umbra_iterate_shadow_memory(map, NULL, umbra_map_shadow_free);
     for (i = 0; i < MAX_NUM_APP_SEGMENTS; i++) {
-        if (app_segments[i].app_used
-            && app_segments[i].map[map->index] == map) {
+        if (app_segments[i].app_used && app_segments[i].map[map->index] == map) {
             size_t size;
             app_segment_t *seg = &app_segments[i];
             size = seg->shadow_end[map->index] - seg->shadow_base[map->index];
             size = size / map->shadow_block_size / BIT_PER_BYTE;
             global_free(seg->shadow_bitmap[map->index], size, HEAPSTAT_SHADOW);
+            seg->shadow_bitmap[map->index] = NULL;
+            seg->shadow_base[map->index] = NULL;
+            seg->shadow_end[map->index] = NULL;
+            seg->reserve_base[map->index] = NULL;
+            seg->reserve_end[map->index] = NULL;
         }
+        /* We never disable the app_used field (except on umbra_arch_exit()). */
     }
 }
 


### PR DESCRIPTION
Adds support to Umbra for the 2TB below-libraries reservation made by
Control Flow Guard.  This requires a new mapping offset for DOWN_8 and
DOWN_4 and a new mask for UP_2X, along with support for a single app
allocation spanning multiple Umbra segments.  Both the multi-segment
support and extra mask bits should not cause any problems, but neither
has been done before.

Adds additional automated checking for a reserve region overlapping
with the shadow region for a mapping.

Adds a new test of every Umbra shadow scale factor.  The test found
bugs in the existing scheme: UP_2X didn't handle app 200'-300'
properly.  That is now fixed.

Builds the umbra test app with /guard:cf to test Control Flow Guard.
Unfortunately the 2TB reservation only seems to happen with VS2017.  I
did manual testing with a VS2017 build of the test app.

Adds proper reset of Umbra state to allow tearing down and restarting
Umbra with a new scheme.

Changes DrM's -define_unknown_regions behavior to invoke mmap_walk()
(and fixes a bug in mmap_walk) to only shadow-define committed memory,
avoiding an attempt to shadow-define the whole 2TB region.

Fixes #2184