### PR TITLE
Release 2.3.0 (#2246)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_deploy:
   # We should find a way to share (xref DRi#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
   # multiple unique tags in one day (the patchlevel here is the day number).
-  - export GIT_TAG="cronbuild-2.2.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  - export GIT_TAG="cronbuild-2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
   - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
 deploy:
   provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ endif (APPLE)
 
 # N.B.: when updating this, update the git tag in .travis.yml.
 # We should find a way to share (xref DRi#1565).
-set(VERSION_NUMBER_DEFAULT "2.2.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "2.3.${VERSION_NUMBER_PATCHLEVEL}")
 # Do not store the default TOOL_VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir.
 # Avoid "VERSION_NUMBER" name since conflics w/ DR's var.

--- a/common/utils_shared.c
+++ b/common/utils_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -85,8 +85,9 @@ drmem_strdup(const char *src, heapstat_t type)
 {
     char *dup = NULL;
     if (src != NULL) {
-        dup = global_alloc(strlen(src)+1, type);
-        strncpy(dup, src, strlen(src)+1);
+        size_t len = strlen(src);
+        dup = global_alloc(len+1, type);
+        strncpy(dup, src, len+1);
     }
     return dup;
 }

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -142,8 +142,8 @@ IGNORE_PREFIX          =
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
-HTML_HEADER            = header.html
-HTML_FOOTER            = footer.html
+HTML_HEADER            =
+HTML_FOOTER            =
 HTML_STYLESHEET        =
 GENERATE_HTMLHELP      = NO
 CHM_FILE               =
@@ -222,7 +222,6 @@ TAGFILES               =
 GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------

--- a/drmemory/docs/errors.dox
+++ b/drmemory/docs/errors.dox
@@ -21,12 +21,12 @@
  */
 
 /* Conventions:
- * + We use \verbatim b/c it nicely highlights command lines, but
- *   because aliases aren't expanded in \verbatim (or \code), we have
+ * + We use \\verbatim b/c it nicely highlights command lines, but
+ *   because aliases aren't expanded in \\verbatim (or \\code), we have
  *   a pre-processing pass that replaces them.  We used to use
- *   \par<tt>...</tt> to get aliases expanded but it doesn't look
- *   as nice.  Note that \if is NOT supported by the script so
- *   use it outside the \verbatim.
+ *   \\par<tt>...</tt> to get aliases expanded but it doesn't look
+ *   as nice.  Note that \\if is NOT supported by the script so
+ *   use it outside the \\verbatim.
  */
 
 /**

--- a/drmemory/docs/light.dox
+++ b/drmemory/docs/light.dox
@@ -21,12 +21,12 @@
  */
 
 /* Conventions:
- * + We use \verbatim b/c it nicely highlights command lines, but
- *   because aliases aren't expanded in \verbatim (or \code), we have
+ * + We use \\verbatim b/c it nicely highlights command lines, but
+ *   because aliases aren't expanded in \\verbatim (or \\code), we have
  *   a pre-processing pass that replaces them.  We used to use
- *   \par<tt>...</tt> to get aliases expanded but it doesn't look
- *   as nice.  Note that \if is NOT supported by the script so
- *   use it outside the \verbatim.
+ *   \\par<tt>...</tt> to get aliases expanded but it doesn't look
+ *   as nice.  Note that \\if is NOT supported by the script so
+ *   use it outside the \\verbatim.
  */
 
 /**

--- a/drmemory/docs/release.dox
+++ b/drmemory/docs/release.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -60,8 +60,13 @@ The Dr. Memory distribution contains the following:
 \section sec_changes Changes Since Prior Releases
 
 The current version is \TOOL_VERSION.
-The changes between \TOOL_VERSION and version 2.2.0 include:
+The changes between \TOOL_VERSION and version 2.3.0 include:
  - Nothing yet.
+
+The changes between version 2.3.0 and version 2.2.0 include:
+ - Added preliminary 64-bit Mac OSX support for small single-threaded
+   applications.
+ - Added recent Windows 10 support to the drstrace and drltrace tools.
 
 The changes between version 2.2.0 and version 2.1.0 include:
  - Fixed a problem with Windows 10 1903.

--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1034,11 +1034,11 @@ memory_walk(void)
                 LOG(2, "  => heap\n");
                 /* we call heap_region_add in heap_iter_region from heap_walk  */
                 if (info.prot == DR_MEMPROT_NONE) {
-                    /* DR's -emulate_brk mmaps a page that we do not want to mark
+                    /* DR's -emulate_brk mmaps 4MB that we do not want to mark
                      * defined, so skip it:
                      */
                     LOG(2, "  initial heap is empty: skipping -emulate_brk page\n");
-                    info.size += PAGE_SIZE;
+                    info.size += 4*1024*1024;
                 }
             } else if (hashtable_lookup(&known_table, (void*)PAGE_START(pc)) != NULL) {
                 /* we assume there's only one entry in the known_table:

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -393,6 +393,7 @@ static const app_segment_t app_segments_initial[] = {
     { NULL, NULL, 0 },
     { NULL, NULL, 0 },
 };
+# ifdef WINDOWS
 static const app_segment_t app_segments_initial_81[] = {
     {(app_pc)0x0000000000000000,  (app_pc)0x0000030000000000, 0},
     /* To ensure we cover large mappings such as from Control Flow Guard without
@@ -407,6 +408,7 @@ static const app_segment_t app_segments_initial_81[] = {
     { NULL, NULL, 0 },
     { NULL, NULL, 0 },
 };
+# endif
 #endif
 #define MAX_NUM_APP_SEGMENTS sizeof(app_segments_initial)/sizeof(app_segments_initial[0])
 static app_segment_t app_segments[MAX_NUM_APP_SEGMENTS];


### PR DESCRIPTION
Updates the version to 2.3.0.
Updates DR to 6d7e906d to fix DRi#4081: Mach-O indirect symbol lookup bug.
Tweaks Doxygen and a few files to build with clang 11.0 on Mac.
Updates the memory walk for the new 4MB emulate_brk mmap.